### PR TITLE
Fix url to the project homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "author": "kenny wong <wowohoo@qq.com>",
   "license": "MIT",
-  "homepage": "http://jaywcjlove.github.io/hotkeys",
+  "homepage": "https://jaywcjlove.github.io/hotkeys-js",
   "repository": {
     "type": "git",
     "url": "https://github.com/jaywcjlove/hotkeys.git"


### PR DESCRIPTION
The old unsecure URL returned a 404. This commit fixes the project homepage by pointing to the correct URL, taken from GitHub

[ci skip]

---

Use case: this url is visible and clickable when in example you run `yarn outdated` in the console

```
$ yarn outdated
yarn outdated v1.22.19
Package                                  Current Wanted Latest  Package Type    URL                                                           
hotkeys-js                               3.10.4  3.11.0 3.11.0  dependencies    http://jaywcjlove.github.io/hotkeys                           
✨  Done in 6.51s.
```