### PR TITLE
Add getAllKeyCodes method to API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,21 @@ function getPressedKeyString() {
   return _downKeys.map((c) => getKey(c) || getModifier(c) || String.fromCharCode(c));
 }
 
+function getAllKeyCodes() {
+  return []
+    .concat(...Object.values(_handlers))
+    .map(({ key, scope, mods, shortcut }) => {
+      return {
+        scope,
+        shortcut,
+        mods,
+        keys: key.split('+').map((k) => {
+          return code(k);
+        }),
+      };
+    });
+}
+
 // 表单控件控件判断 返回 Boolean
 // hotkey is effective only when filter return true
 function filter(event) {
@@ -414,6 +429,7 @@ const _api = {
   getScope,
   deleteScope,
   getPressedKeyCodes,
+  getAllKeyCodes,
   isPressed,
   filter,
   trigger,


### PR DESCRIPTION
Add a new method to get list of all the registered codes from _handlers object. This was also raised in #223 way back. Though the workaround could work I think this could be pretty useful to display something like a map of hotkeys on a application.