### PR TITLE
fix: fix types under node16 moduleResolution

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -177,4 +177,4 @@ export interface Hotkeys {
 }
 // https://github.com/eiriklv/react-masonry-component/issues/57
 declare var hotkeys: Hotkeys;
-export default hotkeys;
+export = hotkeys;


### PR DESCRIPTION
The types of this library do not match the actual JS code, leading to a situation where using ESM under the `node16` moduleResolution method in TypeScript, the default export types will fail to resolve. TypeScript is more strict around type compliance with these settings enabled, and therefore requires the types to match.

The JS code does not use a default import, as `export default` in ESM is not identical to `module.exports = `. `export =` can be used in the `index.d.ts` to match the behaviour within the JS file.

More information on this specific issue is available here, https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md