### PR TITLE
fix: `single` config will conflict with other combinations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hotkeys-js",
-  "version": "3.12.2",
+  "version": "3.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hotkeys-js",
-      "version": "3.12.2",
+      "version": "3.13.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.18.9",

--- a/src/index.js
+++ b/src/index.js
@@ -369,6 +369,9 @@ function hotkeys(key, option, method) {
 
   if (typeof option === 'string') scope = option;
 
+  // 如果只允许单个callback，先unbind
+  if (single) unbind(key, scope);
+
   // 对于每个快捷键进行处理
   for (; i < keys.length; i++) {
     key = keys[i].split(splitKey); // 按键列表
@@ -383,8 +386,6 @@ function hotkeys(key, option, method) {
 
     // 判断key是否在_handlers中，不在就赋一个空数组
     if (!(key in _handlers)) _handlers[key] = [];
-    // 如果只允许单个callback，重新设置_handlers
-    if (single) _handlers[key] = [];
 
     _handlers[key].push({
       keyup,

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -577,6 +577,30 @@ describe('\n   Hotkeys.js Test Case222.\n', () => {
     hotkeys.unbind('⌃+a');
   });
 
+  test('HotKeys Key single callback Test Case', async () => {
+    hotkeys('ctrl+s', () => {
+      expect(false).toBeTruthy();
+    });
+    hotkeys('ctrl+s', { single: true }, (e) => {
+      expect(e.keyCode).toBe(83);
+      expect(e.ctrlKey).toBeTruthy();
+    });
+    hotkeys('ctrl+shift+s', { single: true }, (e) => {
+      expect(e.shiftKey).toBeTruthy();
+      expect(e.keyCode).toBe(83);
+      expect(e.ctrlKey).toBeTruthy();
+    });
+    __triggerKeyboardEvent(document.body, 83, {
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    __triggerKeyboardEvent(document.body, 83, {
+      ctrlKey: true,
+    });
+
+    expect.assertions(5);
+  });
+
   // const _modifier = { //修饰键
   //   '⇧': 16, shift: 16,
   //   '⌥': 18, alt: 18, option: 18,


### PR DESCRIPTION
抱歉，之前没有仔细查看源码，写的有问题。没有注意到`_handlers`是per key的

导致一种情况：
```js
    hotkeys('ctrl+s', { single: true }, (e) => {
      expect(e.keyCode).toBe(83);
      expect(e.ctrlKey).toBeTruthy();
    });
    hotkeys('ctrl+shift+s', { single: true }, (e) => {
      expect(e.shiftKey).toBeTruthy();
      expect(e.keyCode).toBe(83);
      expect(e.ctrlKey).toBeTruthy();
    });
```

`ctrl+s`不会触发，只会触发后绑定的`ctrl+shift+s` (因为s重复。ctrl是特殊键不算重复)

这次修复了这个问题 (不会重置 _handlers，而是内部调用 unbind)，顺便加了对应的test