### PR TITLE
Improve issue where keyup is not fired when command key is pressed / 修复 command 键按下时 keyup 不触发的问题

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,20 +248,19 @@ function dispatch(event, element) {
    * Jest test cases are required.
    * ===============================
    */
-  ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'].forEach((keyName) => {
+  ['metaKey', 'ctrlKey', 'altKey', 'shiftKey'].forEach((keyName) => {
     const keyNum = modifierMap[keyName];
     if (event[keyName] && _downKeys.indexOf(keyNum) === -1) {
       _downKeys.push(keyNum);
     } else if (!event[keyName] && _downKeys.indexOf(keyNum) > -1) {
       _downKeys.splice(_downKeys.indexOf(keyNum), 1);
     } else if (keyName === 'metaKey' && event[keyName] && _downKeys.length === 3) {
-      /**
-       * Fix if Command is pressed:
-       * ===============================
-       */
-      if (!(event.ctrlKey || event.shiftKey || event.altKey)) {
-        _downKeys = _downKeys.slice(_downKeys.indexOf(keyNum));
-      }
+      // 如果command被按下，那就清空所有除event按键外的非装饰键。
+      // 因为command被按下的情况下非装饰键的keyup永远都不会触发。这是已知的浏览器限制。
+      // If command key is pressed, clear all non-decorating keys except for key in event.
+      // This is because keyup for a non-decorating key will NEVER be triggered when command is pressed.
+      // This is a known browser limitation.
+      _downKeys = _downKeys.filter((k) => k in modifierMap || k === key);
     }
   });
   /**


### PR DESCRIPTION
中文见下方

Currently, if one were to register two hotkeys with command key like "Command + Shift + ArrowLeft" and "Command + Shift + ArrowRight", they will not be reliably triggered. To reproduce:

1. Hold down Command and Shift key.
2. Press and release left arrow. The hotkey should trigger.
3. Now, while still holding command and shift keys, press and release right arrow. The hotkey **will not** trigger.

The reason of this issue is that when command key is pressed, `keyup` for a non-modifier key will not trigger. This is a known browser limitation. As a result, hotkeys never knew about the left arrow being let go. In its internal state, when the right arrow is pressed, the `_downKeys` include both arrow left and arrow right. This is incorrect.

This PR brings a solution where, if command key is pressed, any non-modifier key that is not the event key will be removed from `_downKeys`. Because `keyup` is never fired for them, we need to manually release them when command is pressed.

---

当前注册多个带有command的hotkeys（比如“Command + Shift + ArrowLeft”和“Command + Shift + ArrowRight”）的情况下，触发不稳定。重现步骤如下：

1. 按住 Command 和 Shift 键。
2. 按下并释放左箭头键，快捷键应该会触发。
3. 继续按住 Command 和 Shift 键，然后按下并释放右箭头键，此时快捷键**就不会**触发。

出现此问题的原因是，当 command 键被按下时，非修饰键的 `keyup` 事件不会触发。这是已知的浏览器限制。结果就是快捷键内部状态无法得知左箭头键已被释放。在上面提到的例子中，当按下右箭头键时，内部状态中`_downKeys`包含了左箭头键和右箭头键。这就不对了。

此 PR 提供的解决方案是：当 command 键被按下时，任何不是当前事件触发的非修饰键都会从 `_downKeys` 中移除。由于它们的 `keyup` 事件不会被触发，我们需要在 command 被按下时手动释放它们。

致maintainers：可以用中文和我交流。