### PR TITLE
Remove unnecessary if condition for meta key handling / 去除处理meta key的多余if条件判断

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,7 @@ function dispatch(event, element) {
       _downKeys.push(keyNum);
     } else if (!event[keyName] && _downKeys.indexOf(keyNum) > -1) {
       _downKeys.splice(_downKeys.indexOf(keyNum), 1);
-    } else if (keyName === 'metaKey' && event[keyName] && _downKeys.length === 3) {
+    } else if (keyName === 'metaKey' && event[keyName]) {
       // 如果command被按下，那就清空所有除event按键外的非装饰键。
       // 因为command被按下的情况下非装饰键的keyup永远都不会触发。这是已知的浏览器限制。
       // If command key is pressed, clear all non-decorating keys except for key in event.


### PR DESCRIPTION
@jaywcjlove 不好意思哈好像上一个PR有一个小问题就是如果command按下时按下了别的装饰键，downkeys不会正确重置。有一个if判断里多了一个多余的条件。这个PR修复一下。麻烦您了😅

测试用html：
```html
<!doctype html>
<title>Keyboard shortcut test</title>
<body>
<script type="module">
  const pre = document.createElement('pre')
  document.body.append(pre)
  window.addEventListener('keydown', (e) => {
    const str = [
      e.isComposing ? '(composition)' : false,
      e.ctrlKey ? 'ctrl' : false,
      e.altKey ? 'alt' : false,
      e.metaKey ? 'meta': false,
      e.shiftKey ? 'shift' : false,
      e.key
    ].filter(_ => _).join('+')
    pre.append(str+'\n')
  })

  import hotkey from "./hotkeys.esm.js"
  hotkey('cmd+shift+left', () => pre.append('hotkeys-js cmd+shift+left\n'))
  hotkey('cmd+shift+right', () => pre.append('hotkeys-js cmd+shift+right\n'))
  hotkey('cmd+ctrl+left', () => pre.append('hotkeys-js cmd+shift+left\n'))
  hotkey('cmd+ctrl+right', () => pre.append('hotkeys-js cmd+shift+right\n'))
</script>
```